### PR TITLE
Try anchor js with tooltip instead

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,7 +30,7 @@
   anchors.options = {
     placement: 'left',
     visible: 'touch',
-    icon: '¶',
+    icon: 'Copy to clipboard',
   };
 
   anchors.add('.post .page-content > h2, .post .page-content > h3, .post .page-content > h4, .post .page-content > p, .post .page-content li, .post .page-content > blockquote');

--- a/_sass/components/_anchorjs-link.scss
+++ b/_sass/components/_anchorjs-link.scss
@@ -1,0 +1,25 @@
+.anchorjs-link {
+  /* Display anchor links as tooltip */
+  &:after {
+    display: inline-block;
+    padding: $spacing-01 $spacing-02;
+    transition: opacity .25s linear;
+    border-radius: $spacing-01;
+    background-color: $grey;
+    vertical-align: .8ex;
+    font-weight: 300;
+    color: $white;
+    font-size: 10px;
+    @include font-sans;
+  }
+
+  /* Tooltip arrow */
+  &:before {
+    content: "";
+    display: inline-block;
+    border-top: .3ex solid transparent;
+    border-right: .5ex solid $grey;
+    border-bottom: .3ex solid transparent;
+    vertical-align: .35ex;
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -17,6 +17,7 @@
   "base/grid",
   "base/utils",
 
+  "components/anchorjs-link",
   "components/button",
   "components/infobox",
   "components/label",


### PR DESCRIPTION
This would resolve #55 as well: 

![5308e13dcb9fb86d66c7bf4c2068861b](https://user-images.githubusercontent.com/6668406/85013500-94d02d00-b15c-11ea-9f56-0a67530aa7c3.gif)

It doesn’t look perfect, but at least it shows to readers that clicking or tapping will copy the link to the section. 

In a PR because I’m not sure about it. 
